### PR TITLE
[Fix] Remove dimensions according to their importance

### DIFF
--- a/tap_google_analytics/reports.py
+++ b/tap_google_analytics/reports.py
@@ -74,8 +74,6 @@ PREMADE_REPORTS = [
             "ga:operatingSystem",
             "ga:screenResolution",
             "ga:screenColors",
-            "ga:flashVersion",
-            "ga:javaEnabled",
             "ga:hostname"
         ],
         "default_dimensions": [


### PR DESCRIPTION
# Description of change
Removed two dimensions: ga:flashVersion, and ga:javaEnabled, due to their generally lower impact on current web analytics goals compared to the other dimensions. Updated the catalog to reflect those changes. Max allowed number of dimensions is 9.

# Rollback steps
 - revert this branch
