### PR TITLE
[Fix] Remove not allowed metrics

### DIFF
--- a/tap_google_analytics/reports.py
+++ b/tap_google_analytics/reports.py
@@ -107,7 +107,6 @@ PREMADE_REPORTS = [
         "name": "Behavior Overview",
         "metrics": [
             "ga:pageviews",
-            "ga:uniquePageviews",
             "ga:avgTimeOnPage",
             "ga:bounceRate",
             "ga:exitRate",


### PR DESCRIPTION
# Description of change
Remove a metric that can't be requested with the current report request.
Analyzing it with the query builder, `ga:uniquePageviews` was the only metric that can't be selected with the dimensions set from the hardcoded premade report.
<img width="1098" alt="Screenshot 2024-03-11 at 12 58 44" src="https://github.com/singer-io/tap-google-analytics/assets/75049447/8956098e-c181-491d-a47d-195e9552920d">

# Rollback steps
 - revert this branch
