### PR TITLE
[Fix] Review dimensions and metrics for Behavior and Acquisition reports

### DIFF
--- a/tap_google_analytics/reports.py
+++ b/tap_google_analytics/reports.py
@@ -86,15 +86,22 @@ PREMADE_REPORTS = [
         "name": "Acquisition Overview",
         "metrics": [
             "ga:sessions",
-            "ga:pageviewsPerSession",
+            "ga:users",
+            "ga:newUsers",
+            "ga:sessionDuration"
             "ga:avgSessionDuration",
-            "ga:bounceRate"
+            "ga:bounceRate",
+            "ga:pageviews",
+            "ga:pageviewsPerSession",
+            "ga:goalConversionRateAll"
         ],
         "dimensions": [
-            'ga:acquisitionMedium',
-            'ga:acquisitionSource',
-            'ga:acquisitionSourceMedium',
-            'ga:acquisitionTrafficChannel'
+            "ga:date",
+            "ga:medium",
+            "ga:source",
+            "ga:sourceMedium",
+            "ga:campaign",
+            "ga:channelGrouping",
         ],
         "default_dimensions": [
             "ga:acquisitionTrafficChannel",
@@ -118,9 +125,8 @@ PREMADE_REPORTS = [
             "ga:month",
             "ga:hour",
             "ga:pagePath",
-            "ga:pageTitle",
-            "ga:searchKeyword",
-            "ga:eventCategory"
+            "ga:eventCategory",
+            "ga:eventAction",
         ],
         "default_dimensions": [
             "ga:date",


### PR DESCRIPTION
# Description of change
Made changes on the Behavior Overview & Acquisitions Overview, as a customer reported that no data is being replicated. We aim to mimic the reports that the Google Analytics dashboard shows for the customers, and the customer pointed out that they could see data on their end, so changed the dimensions and metrics for the mentioned reports.
Followed the recommended metrics/dimensions suggested by ChatGPT, while maintaining the necessary date field dimensions that we need.
https://chat.openai.com/share/e/2c8ceff1-5e54-4906-af98-df6cfcd55699

# Rollback steps
 - revert this branch
