### PR TITLE
Update jwt version to fix pip conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "singer-python==5.9.0",
         "requests==2.22.0",
         "backoff==1.8.0",
-        "jwt==0.6.1"
+        "jwt==1.1.0"
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
# Description of change
These has been an issue with metadata for the version of jwt (it's not being supported by the newest version of pip)
In order to fix that, updated jwt version to a higher one, which upgrades the version of cryptography (which had the invalid version metadata)
<img width="1516" alt="Screenshot 2024-06-24 at 17 15 51" src="https://github.com/flydata/tap-google-analytics/assets/15137495/b42ae92f-e838-4a34-94bc-ee6aed9dffb1">

[JWT Releases](https://github.com/GehirnInc/python-jwt/tags)

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
